### PR TITLE
Add additional test for rendering multiple Lottie frames

### DIFF
--- a/swift-tests/LottieTests.swift
+++ b/swift-tests/LottieTests.swift
@@ -71,8 +71,12 @@ final class LottieTests: XCTestCase {
         let lottie = try Lottie(path: testLottieUrl.path)
         var buffer = [UInt32](repeating: 0, count: Int(testSize.width * testSize.height))
 
-        for index in 0 ..< lottie.numberOfFrames {
-            try lottie.renderFrame(at: index, into: &buffer, stride: Int(testSize.width), size: testSize)
+        do {
+            for index in 0 ..< lottie.numberOfFrames {
+                try lottie.renderFrame(at: index, into: &buffer, stride: Int(testSize.width), size: testSize)
+            }
+        } catch {
+            XCTFail("Expected to render all lottie frames successfully, but \(error) error was thrown")
         }
     }
 

--- a/swift-tests/LottieTests.swift
+++ b/swift-tests/LottieTests.swift
@@ -67,6 +67,15 @@ final class LottieTests: XCTestCase {
         XCTAssertTrue(bufferHasContent, "Buffer should have non-zero values after rendering.")
     }
 
+    func testRender_WithAllAvailableFramesOfLottie_Succeeds() throws {
+        let lottie = try Lottie(path: testLottieUrl.path)
+        var buffer = [UInt32](repeating: 0, count: Int(testSize.width * testSize.height))
+
+        for index in 0 ..< lottie.numberOfFrames {
+            try lottie.renderFrame(at: index, into: &buffer, stride: Int(testSize.width), size: testSize)
+        }
+    }
+
     func testRender_WithFrameIndexBelowBounds_ThrowsError() throws {
         let lottie = try Lottie(path: testLottieUrl.path)
         var buffer = [UInt32](repeating: 0, count: Int(testSize.width * testSize.height))


### PR DESCRIPTION
This is a small change to increase test coverage over the `render()` function. 

