### PR TITLE
Remove duplicate typealias

### DIFF
--- a/swift/Canvas.swift
+++ b/swift/Canvas.swift
@@ -2,9 +2,6 @@ import CoreGraphics
 
 import thorvg
 
-/// Shorthand alias for the buffer type, representing image pixel data in a mutable pointer to UInt32.
-public typealias Buffer = UnsafeMutablePointer<UInt32>
-
 /// A Swift wrapper for ThorVG's Canvas, facilitating drawing operations.
 class Canvas {
     /// Pointer to the underlying ThorVG canvas object.


### PR DESCRIPTION
A small bug that must have got caught as we merged the previous PRs.

The `Buffer` typealias is already defined in [` LottieRenderer `](https://github.com/andyf-canva/thorvg-swift/blob/5a91849a27ea44a93f0cdb6c2e2cd9e859110ea7/swift/LottieRenderer.swift#L6).